### PR TITLE
prevent excessive logging and cancel[ch164682]

### DIFF
--- a/src/pipecat/transports/network/fastapi_websocket.py
+++ b/src/pipecat/transports/network/fastapi_websocket.py
@@ -269,6 +269,12 @@ class FastAPIWebsocketOutputTransport(BaseOutputTransport):
             if payload:
                 await self._client.send(payload)
         except Exception as e:
+            msg = str(e).lower()
+            if "cannot call" in msg and "once a close message has been sent" in msg:
+                logger.info(f"{self} detected closed websocket, shutting down pipeline")
+                await self.cancel(CancelFrame())
+                return
+            # Otherwise, log as before
             logger.error(f"{self} exception sending data: {e.__class__.__name__} ({e})")
 
     async def _write_audio_sleep(self):


### PR DESCRIPTION
Prevent excessive logging of error below and cancel pipeline immediately instead

```
2025-05-02 22:22:03.007 | ERROR    | pipecat.transports.network.fastapi_websocket:_write_frame:272 - FastAPIWebsocketOutputTransport#0 exception sending data: RuntimeError (Cannot call "send" once a close message has been sent.)
```

When using this to replicate https://github.com/homelight/hl-voice-ai/pull/31/files it will print the error only once and end the pipeline. 

Excessive logging can lock up the current call and even new sessions to the same worker. 