### PR TITLE
Fix websocket receive task cancellation handling

### DIFF
--- a/src/pipecat/services/websocket_service.py
+++ b/src/pipecat/services/websocket_service.py
@@ -72,6 +72,9 @@ class WebsocketService(ABC):
                         self._websocket.close_sent,
                         self._websocket.close_rcvd_then_sent,
                     )
+            except asyncio.CancelledError:
+                logger.debug(f"{self} receive task cancelled")
+                break
             except Exception as e:
                 message = f"{self} error receiving messages: {e}"
                 logger.error(message)


### PR DESCRIPTION
## Summary
- stop websocket service receive loop when the task is cancelled

## Testing
- `pre-commit --version` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_b_68522a295728832ea2317884aaddeeaa