### PR TITLE
Fix race between cancellation and interruptions

### DIFF
--- a/src/pipecat/pipeline/parallel_pipeline.py
+++ b/src/pipecat/pipeline/parallel_pipeline.py
@@ -149,7 +149,8 @@ class ParallelPipeline(BasePipeline):
 
         # Handle interruptions after everything has been cancelled.
         if isinstance(frame, StartInterruptionFrame):
-            await self._handle_interruption()
+            if not self._cancelling:
+                await self._handle_interruption()
         # Wait for tasks to finish.
         elif isinstance(frame, EndFrame):
             await self._stop()

--- a/src/pipecat/processors/frame_processor.py
+++ b/src/pipecat/processors/frame_processor.py
@@ -292,6 +292,9 @@ class FrameProcessor(BaseObject):
     #
 
     async def _start_interruption(self):
+        if self._cancelling:
+            logger.trace(f"{self}: skipping interruption restart while cancelling")
+            return
         try:
             # Cancel the push frame task. This will stop pushing frames downstream.
             await self.__cancel_push_task()

--- a/src/pipecat/services/cartesia/tts.py
+++ b/src/pipecat/services/cartesia/tts.py
@@ -240,6 +240,8 @@ class CartesiaTTSService(AudioContextWordTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         await self.stop_all_metrics()
         if self._context_id:
             cancel_msg = json.dumps({"context_id": self._context_id, "cancel": True})

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -375,6 +375,8 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
 
         # Close the current context when interrupted without closing the websocket
         if self._context_id and self._websocket:

--- a/src/pipecat/services/fish/tts.py
+++ b/src/pipecat/services/fish/tts.py
@@ -167,6 +167,8 @@ class FishAudioTTSService(InterruptibleTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         await self.stop_all_metrics()
         self._request_id = None
 

--- a/src/pipecat/services/playht/tts.py
+++ b/src/pipecat/services/playht/tts.py
@@ -241,6 +241,8 @@ class PlayHTTTSService(InterruptibleTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         await self.stop_all_metrics()
         self._request_id = None
 

--- a/src/pipecat/services/rime/tts.py
+++ b/src/pipecat/services/rime/tts.py
@@ -223,6 +223,8 @@ class RimeTTSService(AudioContextWordTTSService):
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         """Handle interruption by clearing current context."""
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         await self.stop_all_metrics()
         if self._context_id:
             await self._get_websocket().send(json.dumps(self._build_clear_msg()))

--- a/src/pipecat/services/tavus/video.py
+++ b/src/pipecat/services/tavus/video.py
@@ -168,7 +168,8 @@ class TavusVideoService(AIService):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, StartInterruptionFrame):
-            await self._handle_interruptions()
+            if not self._cancelling:
+                await self._handle_interruptions()
             await self.push_frame(frame, direction)
         elif isinstance(frame, TTSAudioRawFrame):
             await self._queue.put(frame)
@@ -176,6 +177,8 @@ class TavusVideoService(AIService):
             await self.push_frame(frame, direction)
 
     async def _handle_interruptions(self):
+        if self._cancelling:
+            return
         await self._cancel_send_task()
         await self._create_send_task()
         await self._client.send_interrupt_message()

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -246,6 +246,8 @@ class TTSService(AIService):
             await self._stop_frame_queue.put(frame)
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
+        if self._cancelling:
+            return
         self._processing_text = False
         await self._text_aggregator.handle_interruption()
         for filter in self._text_filters:
@@ -364,6 +366,8 @@ class WordTTSService(TTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         self._llm_response_started = False
         self.reset_word_timestamps()
 
@@ -438,6 +442,8 @@ class InterruptibleTTSService(WebsocketTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         if self._bot_speaking:
             await self._disconnect()
             await self._connect()
@@ -491,6 +497,8 @@ class InterruptibleWordTTSService(WebsocketWordTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         if self._bot_speaking:
             await self._disconnect()
             await self._connect()
@@ -573,6 +581,8 @@ class AudioContextWordTTSService(WebsocketWordTTSService):
 
     async def _handle_interruption(self, frame: StartInterruptionFrame, direction: FrameDirection):
         await super()._handle_interruption(frame, direction)
+        if self._cancelling:
+            return
         await self._stop_audio_context_task()
         self._create_audio_context_task()
 

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -321,6 +321,8 @@ class BaseOutputTransport(FrameProcessor):
         async def handle_interruptions(self, _: StartInterruptionFrame):
             if not self._transport.interruptions_allowed:
                 return
+            if self._transport._cancelling:
+                return
 
             # Cancel tasks.
             await self._cancel_audio_task()


### PR DESCRIPTION
## Summary
- prevent FrameProcessor from restarting tasks when cancelling
- avoid recreating transport tasks after cancellation
- guard interruption handlers in transports and services
- skip parallel pipeline interruptions once cancelling

## Testing
- `ruff format --diff`
- `ruff check --select I`

------
https://chatgpt.com/codex/tasks/task_b_68586d825b84832e9ed399fec85fb7b3